### PR TITLE
Fix build artifacts not being correctly copied between jobs

### DIFF
--- a/.github/workflows/build-and-deploy-to-s3.yml
+++ b/.github/workflows/build-and-deploy-to-s3.yml
@@ -30,7 +30,7 @@ jobs:
     name: Deploy to S3
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/master'
+    # if: github.ref == 'refs/heads/master'
     env:
       AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
       AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
@@ -43,6 +43,8 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: dist
+
+    - run: ls -la dist
 
     - name: Run Ansible playbook
       uses: ./.github/actions/ansible-playbook

--- a/.github/workflows/build-and-deploy-to-s3.yml
+++ b/.github/workflows/build-and-deploy-to-s3.yml
@@ -26,13 +26,11 @@ jobs:
         name: dist
         path: dist
 
-    - run: ls -la dist
-
   deploy:
     name: Deploy to S3
     runs-on: ubuntu-latest
     needs: build
-    # if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     env:
       AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
       AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
@@ -47,9 +45,7 @@ jobs:
         name: dist
         path: dist
 
-    - run: ls -la dist
-
-    # - name: Run Ansible playbook
-    #   uses: ./.github/actions/ansible-playbook
-    #   with:
-    #     playbook: deploy/deploy-to-s3.yml
+    - name: Run Ansible playbook
+      uses: ./.github/actions/ansible-playbook
+      with:
+        playbook: deploy/deploy-to-s3.yml

--- a/.github/workflows/build-and-deploy-to-s3.yml
+++ b/.github/workflows/build-and-deploy-to-s3.yml
@@ -26,6 +26,8 @@ jobs:
         name: dist
         path: dist
 
+    - run: ls -la dist
+
   deploy:
     name: Deploy to S3
     runs-on: ubuntu-latest
@@ -43,10 +45,11 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: dist
+        path: dist
 
     - run: ls -la dist
 
-    - name: Run Ansible playbook
-      uses: ./.github/actions/ansible-playbook
-      with:
-        playbook: deploy/deploy-to-s3.yml
+    # - name: Run Ansible playbook
+    #   uses: ./.github/actions/ansible-playbook
+    #   with:
+    #     playbook: deploy/deploy-to-s3.yml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [heyitsme.fyi](https://heyitsme.fyi)
 
-![Build and deploy to S3](https://github.com/xrossb/heyitsme.fyi/workflows/Build%20and%20deploy%20to%20S3/badge.svg)
+[![Build and deploy to S3](https://github.com/xrossb/heyitsme.fyi/actions/workflows/build-and-deploy-to-s3.yml/badge.svg)](https://github.com/xrossb/heyitsme.fyi/actions/workflows/build-and-deploy-to-s3.yml)
 
 My personal website, built and deployed automatically w/ GitHub Actions + Ansible.


### PR DESCRIPTION
The usage of `actions/download-artifact@v2` in "Deploy to S3" was missing the `path` setting, causing build artifacts to be downloaded to the wrong directory and missed by `s3_sync`.